### PR TITLE
fix(ci): Add empty inputs to workflow_dispatch

### DIFF
--- a/nca-toolkit-ja-overlay/.github/workflows/monthly-rebuild.yml
+++ b/nca-toolkit-ja-overlay/.github/workflows/monthly-rebuild.yml
@@ -1,6 +1,7 @@
 name: monthly-rebuild
 on:
   workflow_dispatch:
+    inputs: {}
   schedule:
     - cron:  '15 21 30 * *'
 jobs:


### PR DESCRIPTION
This should enable manual triggering of the workflow.